### PR TITLE
コンソールから実行する場合のオプション指定付きのコマンドを追記

### DIFF
--- a/Textbook/Capturing-Output.md
+++ b/Textbook/Capturing-Output.md
@@ -39,3 +39,9 @@ namespace CapturingOutput.Tests
 ```
 
 ITestOutputHelperをコンストラクタでインジェクションしてもらい利用します。ITestOutputHelperはConsoleクラスと同様の出力フォーマットをサポートしています。
+
+## コンソールから実行する場合
+コンソールからテスト実行する場合は、--loggerオプションを付けて実行します。
+```cmd
+dotnet test --logger:"console;verbosity=detailed"
+```


### PR DESCRIPTION
まだテストの実行方法の説明はありませんが、デバッグ出力でコンソールからテストを実行する場合だけはオプション引数が必要なのでひとまず記載の提案です。